### PR TITLE
Add withAuth, modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [_Unreleased_](https://github.com/freckle/amazonka-mtl/compare/v0.1.0.0...main)
+## [_Unreleased_](https://github.com/freckle/amazonka-mtl/compare/v0.1.1.0...main)
+
+## [v0.1.1.0](https://github.com/freckle/amazonka-mtl/compare/v0.1.0.0...v0.1.1.0)
+
+- Add `withAuth` and `modified`
 
 ## [v0.1.0.0](https://github.com/freckle/amazonka-mtl/tree/v0.1.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [v0.1.1.0](https://github.com/freckle/amazonka-mtl/compare/v0.1.0.0...v0.1.1.0)
 
-- Add `withAuth` and `modified`
+- Add `withAuth` and `localEnv`
 
 ## [v0.1.0.0](https://github.com/freckle/amazonka-mtl/tree/v0.1.0.0)
 

--- a/amazonka-mtl.cabal
+++ b/amazonka-mtl.cabal
@@ -105,7 +105,7 @@ library
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-unsafe -Wno-safe
+  ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe
   build-depends:
       amazonka
     , amazonka-core
@@ -151,7 +151,7 @@ test-suite readme
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-unsafe -Wno-safe -pgmL markdown-unlit
+  ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe -pgmL markdown-unlit
   build-depends:
       Blammo
     , amazonka-core
@@ -201,7 +201,7 @@ test-suite spec
       StandaloneDeriving
       TypeApplications
       TypeFamilies
-  ghc-options: -Weverything -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-unsafe -Wno-safe -threaded -rtsopts "-with-rtsopts=-N"
+  ghc-options: -Weverything -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-safe -Wno-unsafe -threaded -rtsopts "-with-rtsopts=-N"
   build-depends:
       amazonka-core
     , amazonka-mtl

--- a/amazonka-mtl.cabal
+++ b/amazonka-mtl.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.18
 -- see: https://github.com/sol/hpack
 
 name:           amazonka-mtl
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:       MTL-style type-class and deriving-via newtypes for Amazonka
 description:    This package allows incorporation of AWS actions into any MTL-style function,
                 .

--- a/library/Control/Monad/AWS.hs
+++ b/library/Control/Monad/AWS.hs
@@ -26,6 +26,8 @@ import qualified Data.Conduit as Conduit
 import Data.Typeable (Typeable)
 
 -- | Version of 'Amazonka.send' built on our 'sendEither'
+--
+-- @since 0.1.0.0
 send
   :: ( MonadIO m
      , MonadAWS m
@@ -38,6 +40,8 @@ send
 send = sendEither >=> hoistEither
 
 -- | Version of 'Amazonka.paginateEither' built on our 'sendEither'
+--
+-- @since 0.1.0.0
 paginateEither
   :: (MonadAWS m, AWSPager a, Typeable a, Typeable (AWSResponse a))
   => a
@@ -52,6 +56,8 @@ paginateEither = go
         maybe (pure (Right ())) go (Pager.page rq rs)
 
 -- | Version of 'Amazonka.paginate' built on our 'paginateEither'
+--
+-- @since 0.1.0.0
 paginate
   :: ( MonadIO m
      , MonadAWS m
@@ -65,6 +71,8 @@ paginate =
   paginateEither >=> hoistEither
 
 -- | Version of 'Amazonka.await' built on our 'awaitEither'
+--
+-- @since 0.1.0.0
 await
   :: (MonadIO m, MonadAWS m, AWSRequest a, Typeable a)
   => Waiter.Wait a

--- a/library/Control/Monad/AWS/Class.hs
+++ b/library/Control/Monad/AWS/Class.hs
@@ -23,17 +23,29 @@ import Data.Typeable (Typeable)
 -- - "Control.Monad.AWS.ViaReader"
 -- - "Control.Monad.AWS.ViaMock"
 class Monad m => MonadAWS m where
+  -- |
+  --
+  -- @since 0.1.0.0
   sendEither
     :: (AWSRequest a, Typeable a, Typeable (AWSResponse a))
     => a
     -> m (Either Error (AWSResponse a))
 
+  -- |
+  --
+  -- @since 0.1.0.0
   awaitEither
     :: (AWSRequest a, Typeable a)
     => Waiter.Wait a
     -> a
     -> m (Either Error Waiter.Accept)
 
+  -- |
+  --
+  -- @since 0.1.1.0
   withAuth :: (AuthEnv -> m a) -> m a
 
+  -- |
+  --
+  -- @since 0.1.1.0
   modified :: (Env -> Env) -> m a -> m a

--- a/library/Control/Monad/AWS/Class.hs
+++ b/library/Control/Monad/AWS/Class.hs
@@ -5,7 +5,9 @@ where
 
 import Amazonka.Prelude
 
+import Amazonka (AuthEnv)
 import Amazonka.Core (AWSRequest, AWSResponse, Error)
+import Amazonka.Env (Env)
 import qualified Amazonka.Waiter as Waiter
 import Data.Typeable (Typeable)
 
@@ -31,3 +33,7 @@ class Monad m => MonadAWS m where
     => Waiter.Wait a
     -> a
     -> m (Either Error Waiter.Accept)
+
+  withAuth :: (AuthEnv -> m a) -> m a
+
+  modified :: (Env -> Env) -> m a -> m a

--- a/library/Control/Monad/AWS/Class.hs
+++ b/library/Control/Monad/AWS/Class.hs
@@ -23,7 +23,7 @@ import Data.Typeable (Typeable)
 -- - "Control.Monad.AWS.ViaReader"
 -- - "Control.Monad.AWS.ViaMock"
 class Monad m => MonadAWS m where
-  -- |
+  -- | The type-class version of 'Amazonka.sendEither'.
   --
   -- @since 0.1.0.0
   sendEither
@@ -31,7 +31,7 @@ class Monad m => MonadAWS m where
     => a
     -> m (Either Error (AWSResponse a))
 
-  -- |
+  -- | The type-class version of 'Amazonka.awaitEither'.
   --
   -- @since 0.1.0.0
   awaitEither
@@ -40,12 +40,15 @@ class Monad m => MonadAWS m where
     -> a
     -> m (Either Error Waiter.Accept)
 
-  -- |
+  -- | Supply the current credentials to the given action.
   --
   -- @since 0.1.1.0
   withAuth :: (AuthEnv -> m a) -> m a
 
-  -- |
+  -- | Run the given action with a modified 'Env'
+  --
+  -- For instances that supply 'Env' via Reader, this should behave like
+  -- 'local'.
   --
   -- @since 0.1.1.0
-  modified :: (Env -> Env) -> m a -> m a
+  localEnv :: (Env -> Env) -> m a -> m a

--- a/library/Control/Monad/AWS/EnvT.hs
+++ b/library/Control/Monad/AWS/EnvT.hs
@@ -33,6 +33,9 @@ import Control.Monad.AWS.ViaReader
 import Control.Monad.Reader
 import Control.Monad.Trans.Resource
 
+-- |
+--
+-- @since 0.1.0.0
 newtype EnvT m a = EnvT
   { unEnvT :: ReaderT Env (ResourceT m) a
   }
@@ -47,5 +50,8 @@ newtype EnvT m a = EnvT
     )
   deriving (MonadAWS) via (ReaderAWS (EnvT m))
 
+-- |
+--
+-- @since 0.1.0.0
 runEnvT :: MonadUnliftIO m => EnvT m a -> Env -> m a
 runEnvT f = runResourceT . runReaderT (unEnvT f)

--- a/library/Control/Monad/AWS/MockT.hs
+++ b/library/Control/Monad/AWS/MockT.hs
@@ -45,6 +45,9 @@ import Control.Monad.AWS.ViaMock
 import Control.Monad.IO.Unlift
 import Control.Monad.Reader
 
+-- |
+--
+-- @since 0.1.0.0
 newtype MockT m a = MockT
   { unMockT :: ReaderT Matchers m a
   }
@@ -58,5 +61,8 @@ newtype MockT m a = MockT
     )
   deriving (MonadAWS) via (MockAWS (MockT m))
 
+-- |
+--
+-- @since 0.1.0.0
 runMockT :: MockT m a -> m a
 runMockT f = runReaderT (unMockT f) mempty

--- a/library/Control/Monad/AWS/ViaMock.hs
+++ b/library/Control/Monad/AWS/ViaMock.hs
@@ -80,11 +80,7 @@ newtype MockAWS m a = MockAWS
 instance (MonadIO m, MonadReader env m, HasMatchers env) => MonadAWS (MockAWS m) where
   sendEither = matchSend
   awaitEither = matchAwait
-
-  -- \| Run the given action with a fake 'AuthEnv'
   withAuth = ($ fakeAuthEnv)
-
-  -- \| Run the given action (there is no 'Env' to modify)
   localEnv _ = id
 
 fakeAuthEnv :: AuthEnv

--- a/library/Control/Monad/AWS/ViaMock.hs
+++ b/library/Control/Monad/AWS/ViaMock.hs
@@ -63,6 +63,9 @@ import Control.Monad.AWS.Matchers
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Reader (MonadReader (..))
 
+-- |
+--
+-- @since 0.1.0.0
 newtype MockAWS m a = MockAWS
   { unMockAWS :: m a
   }

--- a/library/Control/Monad/AWS/ViaMock.hs
+++ b/library/Control/Monad/AWS/ViaMock.hs
@@ -80,8 +80,12 @@ newtype MockAWS m a = MockAWS
 instance (MonadIO m, MonadReader env m, HasMatchers env) => MonadAWS (MockAWS m) where
   sendEither = matchSend
   awaitEither = matchAwait
+
+  -- \| Run the given action with a fake 'AuthEnv'
   withAuth = ($ fakeAuthEnv)
-  modified _ = id
+
+  -- \| Run the given action (there is no 'Env' to modify)
+  localEnv _ = id
 
 fakeAuthEnv :: AuthEnv
 fakeAuthEnv =

--- a/library/Control/Monad/AWS/ViaMock.hs
+++ b/library/Control/Monad/AWS/ViaMock.hs
@@ -57,6 +57,7 @@ module Control.Monad.AWS.ViaMock
 
 import Prelude
 
+import Amazonka (AuthEnv (..))
 import Control.Monad.AWS.Class
 import Control.Monad.AWS.Matchers
 import Control.Monad.IO.Class (MonadIO)
@@ -76,3 +77,14 @@ newtype MockAWS m a = MockAWS
 instance (MonadIO m, MonadReader env m, HasMatchers env) => MonadAWS (MockAWS m) where
   sendEither = matchSend
   awaitEither = matchAwait
+  withAuth = ($ fakeAuthEnv)
+  modified _ = id
+
+fakeAuthEnv :: AuthEnv
+fakeAuthEnv =
+  AuthEnv
+    { accessKeyId = "mock-aws-access-key-id"
+    , secretAccessKey = "mock-aws-secret-key"
+    , sessionToken = Just "mock-aws-sessin-token"
+    , expiration = Nothing
+    }

--- a/library/Control/Monad/AWS/ViaReader.hs
+++ b/library/Control/Monad/AWS/ViaReader.hs
@@ -78,12 +78,21 @@ import Control.Monad.Reader
 import Control.Monad.Trans.Resource (MonadResource)
 import Data.Functor.Identity (runIdentity)
 
+-- |
+--
+-- @since 0.1.0.0
 class HasEnv env where
   envL :: Lens' env Env
 
+-- |
+--
+-- @since 0.1.0.0
 instance HasEnv Env where
   envL = id
 
+-- |
+--
+-- @since 0.1.0.0
 newtype ReaderAWS m a = ReaderAWS
   { unReaderAWS :: m a
   }

--- a/library/Control/Monad/AWS/ViaReader.hs
+++ b/library/Control/Monad/AWS/ViaReader.hs
@@ -118,4 +118,4 @@ instance (MonadResource m, MonadReader env m, HasEnv env) => MonadAWS (ReaderAWS
     auth <- view $ envL . env_auth . to runIdentity
     Amazonka.withAuth auth f
 
-  modified f = local $ envL %~ f
+  localEnv f = local $ envL %~ f

--- a/library/Control/Monad/AWS/ViaReader.hs
+++ b/library/Control/Monad/AWS/ViaReader.hs
@@ -69,12 +69,14 @@ module Control.Monad.AWS.ViaReader
 
 import Prelude
 
+import qualified Amazonka.Auth as Amazonka
 import Amazonka.Env
 import qualified Amazonka.Send as Amazonka
-import Control.Lens (Lens', view)
+import Control.Lens (Lens', to, view, (%~))
 import Control.Monad.AWS.Class
 import Control.Monad.Reader
 import Control.Monad.Trans.Resource (MonadResource)
+import Data.Functor.Identity (runIdentity)
 
 class HasEnv env where
   envL :: Lens' env Env
@@ -102,3 +104,9 @@ instance (MonadResource m, MonadReader env m, HasEnv env) => MonadAWS (ReaderAWS
   awaitEither w a = do
     env <- view envL
     Amazonka.awaitEither env w a
+
+  withAuth f = do
+    auth <- view $ envL . env_auth . to runIdentity
+    Amazonka.withAuth auth f
+
+  modified f = local $ envL %~ f

--- a/package.yaml
+++ b/package.yaml
@@ -58,12 +58,14 @@ extra-source-files:
 
 ghc-options:
   - -Weverything
+  - -Wno-all-missed-specialisations
+  - -Wno-missed-specialisations
   - -Wno-missing-exported-signatures # re-enables missing-signatures
   - -Wno-missing-import-lists
   - -Wno-missing-local-signatures
   - -Wno-monomorphism-restriction
-  - -Wno-unsafe
   - -Wno-safe
+  - -Wno-unsafe
 
 when:
   - condition: "impl(ghc >= 9.2)"

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: amazonka-mtl
-version: 0.1.0.0
+version: 0.1.1.0
 maintainer: Freckle Education
 category: Utils
 github: freckle/amazonka-mtl


### PR DESCRIPTION
There are two very important use-cases that were not currently satisfied
by `MonadAWS`:

- Getting the current credentials, e.g. for explicit passing to other
  tools that are not in this Haskell process
- Modifying `Env` in some way (timeout, logger, etc) for the duration of
  a block

This patch adds two members to the type class to solve this:

`withAuth` matches `Amazonka`'s `withAuth` but without the initial
argument, which is analagous to how `send`-et-al work. This seems like
an uncontroversial extension for that reason.

`modified` is a bit of a stretch, and I'm open to alternative ideas. For
any Reader-like instance, it's just `local`. I could name it `local` to
indicate that, but it's not necessarily the case and it would be a
constant collision, so I went with `modified`. `withEnv` is another
option, though I'd expect such a function to be `(Env -> m a) -> m a`,
which is not the functionality we need, nor what this provides.

In both cases, the `MockAWS` instance has to take some liberties, being
as it's a test instance without anything real going on.
